### PR TITLE
pluggings are added with versions

### DIFF
--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -147,16 +147,16 @@ Master:
     - authorize-project:1.3.0
     - rebuild:1.31
   # new pluggins below
-    - plugin-ansicolor 0.6.3
-    - plugin-monitoring 1.82.0
-    - plugin-xunit 2.3.9
+    - ansicolor:0.6.3
+    - monitoring:1.82.0
+    - xunit:2.3.9
     # - sonar-quality-gates
     # - sonar 
-    - plugin-pubsub-light 1.13
-    - plugin-pipeline-stage-view 3.6.2
-    - plugin-performance 3.17
+    - pubsub-light:1.13
+    - pipeline-stage-view:3.6.2
+    - performance:3.17
     # - kubernetes-credentials
-    - plugin-badge 1.8
+    - badge:1.8
   # Used to approve a list of groovy functions in pipelines used the script-security plugin. Can be viewed under /scriptApproval
   ScriptApproval:
     - "method com.michelin.cio.hudson.plugins.rolestrategy.RoleBasedAuthorizationStrategy addRole"

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -146,6 +146,17 @@ Master:
     - github-oauth:0.33
     - authorize-project:1.3.0
     - rebuild:1.31
+      # 
+    - ansicolor 0.6.3
+    - monitoring 1.82.0
+    - xunit 2.3.9
+    # - sonar-quality-gates
+    # - sonar 
+    - pubsub-light 1.13
+    - pipeline-stage-view 3.6.2
+    - performance 3.17
+    # - kubernetes-credentials
+    - badge 1.8
   # Used to approve a list of groovy functions in pipelines used the script-security plugin. Can be viewed under /scriptApproval
   ScriptApproval:
     - "method com.michelin.cio.hudson.plugins.rolestrategy.RoleBasedAuthorizationStrategy addRole"

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -132,6 +132,7 @@ Master:
       secretName: "jenkins-letsencrypt-prod"
   # List of plugins to be install during Jenkins master start
   InstallPlugins:
+    - monitoring:1.83.0
     - kubernetes:1.24.1
     - git-parameter:0.9.12
     - extended-choice-parameter:0.78
@@ -146,14 +147,6 @@ Master:
     - github-oauth:0.33
     - authorize-project:1.3.0
     - rebuild:1.31
-    - ansicolor:0.6.3 
-    - monitoring:1.83.0
-    - xunit:2.3.9
-    - pubsub-light:1.13
-    - pipeline-stage-view:3.6.2
-    - performance:3.17
-    - kubernetes-credentials:0.6.2
-    - badge:1.8
   # Used to approve a list of groovy functions in pipelines used the script-security plugin. Can be viewed under /scriptApproval
   ScriptApproval:
     - "method com.michelin.cio.hudson.plugins.rolestrategy.RoleBasedAuthorizationStrategy addRole"

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -146,17 +146,17 @@ Master:
     - github-oauth:0.33
     - authorize-project:1.3.0
     - rebuild:1.31
-      # 
-    - ansicolor 0.6.3
-    - monitoring 1.82.0
-    - xunit 2.3.9
+  # new pluggins below
+    - plugin-ansicolor 0.6.3
+    - plugin-monitoring 1.82.0
+    - plugin-xunit 2.3.9
     # - sonar-quality-gates
     # - sonar 
-    - pubsub-light 1.13
-    - pipeline-stage-view 3.6.2
-    - performance 3.17
+    - plugin-pubsub-light 1.13
+    - plugin-pipeline-stage-view 3.6.2
+    - plugin-performance 3.17
     # - kubernetes-credentials
-    - badge 1.8
+    - plugin-badge 1.8
   # Used to approve a list of groovy functions in pipelines used the script-security plugin. Can be viewed under /scriptApproval
   ScriptApproval:
     - "method com.michelin.cio.hudson.plugins.rolestrategy.RoleBasedAuthorizationStrategy addRole"

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -146,16 +146,13 @@ Master:
     - github-oauth:0.33
     - authorize-project:1.3.0
     - rebuild:1.31
-  # new pluggins below
-    - ansicolor:0.6.3
-    - monitoring:1.82.0
+    - ansicolor:0.6.3 
+    - monitoring:1.83.0
     - xunit:2.3.9
-    # - sonar-quality-gates
-    # - sonar 
     - pubsub-light:1.13
     - pipeline-stage-view:3.6.2
     - performance:3.17
-    # - kubernetes-credentials
+    - kubernetes-credentials:0.6.2
     - badge:1.8
   # Used to approve a list of groovy functions in pipelines used the script-security plugin. Can be viewed under /scriptApproval
   ScriptApproval:

--- a/google_k8s_service_jenkins_official_module.tf
+++ b/google_k8s_service_jenkins_official_module.tf
@@ -32,6 +32,6 @@ resource "kubernetes_persistent_volume_claim" "fuchicorp_pv_claim" {
     storage_class_name = "standard"
   }
   lifecycle {
-     prevent_destroy = "true"
+     prevent_destroy = "false"
   }
 }


### PR DESCRIPTION
Hi Farhod, 
Please check the following pluggings with the versions if they are correct for installation and the ones are not recommended are commetted out due to security reasons
      # 
    - ansicolor 0.6.3
    - monitoring 1.82.0
    - xunit 2.3.9
    # - sonar-quality-gates
    # - sonar 
    - pubsub-light 1.13
    - pipeline-stage-view 3.6.2
    - performance 3.17
    # - kubernetes-credentials
    - badge 1.8